### PR TITLE
Fix selector visibility and balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,18 @@
 
         <div class="main-content">
             <div class="farm-grid-container">
+
+                <!-- Wrapper for Grid Layout -->
+                <div class="grid-and-selectors-wrapper">
+                    <!-- Row Selectors Placeholder (Buttons added by JS) -->
+                    <div class="row-selectors"></div>
+                    <!-- Column Selectors Placeholder (Buttons added by JS) -->
+                    <div class="column-selectors"></div>
+                    <!-- Canvas -->
+                    <canvas id="farm-grid"></canvas>
+                </div>
+                <!-- End Wrapper -->
+
                 <!-- Other UI Elements Relative to the Container -->
                 <div class="overlay-controls">
                     <select id="overlay-select">

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -203,7 +203,7 @@ export class CaliforniaClimateFarmer {
     }
 
     runTick() {
-        this.balance -= this.dailyOverhead;
+        this.balance -= this.dailyOverheadCost;
         if (this.balance < -5000 && !this.testMode) {
              this.addEvent("Warning: Farm operating at a significant loss!", true);
         }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -297,9 +297,12 @@ export class UIManager {
         colSelectorsContainer.appendChild(selectAllBtn);
         
         console.log("Selector buttons created");
-        
+
         // Create bulk panel
         this.createBulkActionPanel();
+
+        // Ensure initial positioning
+        setTimeout(() => this.render(), 50);
     }
     
     createBulkActionPanel() {
@@ -501,34 +504,34 @@ export class UIManager {
     _updateSelectorPositions(offsetX, offsetY) {
         const rowSelectors = document.querySelector('.row-selectors');
         const colSelectors = document.querySelector('.column-selectors');
-        
+
         if (!rowSelectors || !colSelectors || !this.game || this.cellSize <= 0 || this.game.gridSize <= 0) {
-            console.warn('Skipping selector position update. Missing elements or invalid parameters.');
-            return;
+            return; // Elements not ready
         }
-        
-        // Calculate grid dimensions
+
         const gridWidth = this.cellSize * this.game.gridSize;
         const gridHeight = this.cellSize * this.game.gridSize;
-        const buttonSize = 24; // Size of selector buttons
-        const margin = 8; // Margin between buttons and grid
-        
-        // Position row selector container
-        rowSelectors.style.left = `${offsetX - buttonSize - margin}px`;
-        rowSelectors.style.top = `${offsetY}px`;
-        rowSelectors.style.height = `${gridHeight}px`;
-        rowSelectors.style.width = 'auto';
-        
-        // Position column selector container
-        colSelectors.style.left = `${offsetX}px`;
-        colSelectors.style.top = `${offsetY - buttonSize - margin}px`;
-        colSelectors.style.width = `${gridWidth}px`;
-        colSelectors.style.height = 'auto';
-        
-        // The flexbox layout will handle individual button spacing
-        // No need to position individual buttons
-        
-        console.log(`Selectors positioned. Grid: ${gridWidth}x${gridHeight}, Offset: (${offsetX},${offsetY})`);
+        const buttonSize = 24;
+        const margin = 8;
+
+        const newRowLeft = `${offsetX - buttonSize - margin}px`;
+        const newRowTop = `${offsetY}px`;
+        const newColLeft = `${offsetX}px`;
+        const newColTop = `${offsetY - buttonSize - margin}px`;
+
+        if (rowSelectors.style.left !== newRowLeft || rowSelectors.style.top !== newRowTop) {
+            rowSelectors.style.left = newRowLeft;
+            rowSelectors.style.top = newRowTop;
+            rowSelectors.style.height = `${gridHeight}px`;
+            rowSelectors.style.width = `${buttonSize}px`;
+        }
+
+        if (colSelectors.style.left !== newColLeft || colSelectors.style.top !== newColTop) {
+            colSelectors.style.left = newColLeft;
+            colSelectors.style.top = newColTop;
+            colSelectors.style.width = `${gridWidth}px`;
+            colSelectors.style.height = `${buttonSize}px`;
+        }
     }
 
     

--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@ h1 {
     display: flex !important;
     flex-direction: column !important;
     justify-content: space-between !important;
-    z-index: 100 !important;
+    z-index: 1000 !important;
     /* These will be set by JavaScript:
     left: calculated
     top: calculated
@@ -104,7 +104,7 @@ h1 {
     display: flex !important;
     flex-direction: row !important;
     justify-content: space-between !important;
-    z-index: 100 !important;
+    z-index: 1000 !important;
     /* These will be set by JavaScript:
     left: calculated
     top: calculated
@@ -161,12 +161,7 @@ h1 {
     background: rgba(76, 175, 80, 1) !important;
 }
 
-/* Reset flexbox layouts that might be interfering */
-.row-selectors, .column-selectors {
-    display: block !important;
-    flex-direction: unset !important;
-    justify-content: unset !important;
-}
+/* Removed legacy flexbox reset that hid selectors */
 /* --- End Grid & Selector Layout --- */
 
 .sidebar {


### PR DESCRIPTION
## Summary
- restore `grid-and-selectors-wrapper` with canvas and selector placeholders
- show row/column selector buttons with higher z-index
- fix daily overhead deduction to avoid NaN balance
- reposition selectors reliably after creation

## Testing
- `node run-tests.js`

------
https://chatgpt.com/codex/tasks/task_e_6841b7c445f483279ecf157ad097944c